### PR TITLE
Add CMake infrastructure for test autodiscovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 
 project(mold VERSION 0.1.1 LANGUAGES C)
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -67,10 +67,6 @@ function(discover_tests TARGET)
   set(ctest_file_base "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}[${counter}]")
   set(ctest_include_file "${ctest_file_base}_include.cmake")
   set(ctest_tests_file "${ctest_file_base}_tests.cmake")
-  get_property(crosscompiling_emulator
-    TARGET ${TARGET}
-    PROPERTY CROSSCOMPILING_EMULATOR
-  )
 
   add_custom_command(
     TARGET ${TARGET} POST_BUILD
@@ -99,10 +95,6 @@ function(discover_tests TARGET)
     APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
   )
 endfunction()
-
-#add_test(
-#  NAME mytest
-#  COMMAND $<TARGET_FILE:md_unittest>)
 
 discover_tests(md_unittest
   PROPERTIES

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -1,15 +1,110 @@
-set(SOURCE_FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/unittest.c
+add_executable(md_unittest unittest.c)
+target_link_libraries(md_unittest PRIVATE mold)
+target_compile_definitions(md_unittest PRIVATE MD_UNITTEST_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/data\")
+
+target_sources(md_unittest
+  PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/test_allocator.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_array.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_bitop.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_intrinsics.c
     ${CMAKE_CURRENT_SOURCE_DIR}/test_script.c
-)
+  )
 
-add_executable(md_unittest ${SOURCE_FILES})
-target_link_libraries(md_unittest PRIVATE mold)
-target_compile_definitions(md_unittest PRIVATE MD_UNITTEST_DATA_DIR=\"${CMAKE_CURRENT_SOURCE_DIR}/data\")
+# adapted from https://github.com/Kitware/CMake/blob/master/Modules/GoogleTest.cmake
+# and https://github.com/Kitware/CMake/blob/master/Modules/GoogleTestAddTests.cmake
+function(discover_tests TARGET)
+  set(options)
+  set(oneValueArgs
+    TARGET
+    WORKING_DIRECTORY
+    DISCOVERY_TIMEOUT
+  )
+  set(multiValueArgs
+    PROPERTIES
+  )
+  cmake_parse_arguments(
+    ""
+    "${options}"
+    "${oneValueArgs}"
+    "${multiValueArgs}"
+    ${ARGN}
+  )
 
-add_test(NAME mytest
-	COMMAND $<TARGET_FILE:md_unittest>)
+  if(NOT _WORKING_DIRECTORY)
+    set(_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+  endif()
+  set(_TEST_LIST ${TARGET}_TESTS)
+  if(NOT _DISCOVERY_TIMEOUT)
+    set(_DISCOVERY_TIMEOUT 5)
+  endif()
+
+  set(_DISCOVERY_MODE POST_BUILD)
+
+  get_property(
+    has_counter
+    TARGET ${TARGET}
+    PROPERTY CTEST_DISCOVERED_TEST_COUNTER
+    SET
+  )
+  if(has_counter)
+    get_property(
+      counter
+      TARGET ${TARGET}
+      PROPERTY CTEST_DISCOVERED_TEST_COUNTER
+    )
+    math(EXPR counter "${counter} + 1")
+  else()
+    set(counter 1)
+  endif()
+  set_property(
+    TARGET ${TARGET}
+    PROPERTY CTEST_DISCOVERED_TEST_COUNTER
+    ${counter}
+  )
+
+  # Define rule to generate test list for aforementioned test executable
+  set(ctest_file_base "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}[${counter}]")
+  set(ctest_include_file "${ctest_file_base}_include.cmake")
+  set(ctest_tests_file "${ctest_file_base}_tests.cmake")
+  get_property(crosscompiling_emulator
+    TARGET ${TARGET}
+    PROPERTY CROSSCOMPILING_EMULATOR
+  )
+
+  add_custom_command(
+    TARGET ${TARGET} POST_BUILD
+    BYPRODUCTS "${ctest_tests_file}"
+    COMMAND "${CMAKE_COMMAND}"
+            -D "TEST_TARGET=${TARGET}"  # maybe not needed?
+            -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>"
+            -D "TEST_WORKING_DIR=${_WORKING_DIRECTORY}"
+            -D "TEST_PROPERTIES=${_PROPERTIES}"
+            -D "CTEST_FILE=${ctest_tests_file}"
+            -D "TEST_DISCOVERY_TIMEOUT=${_DISCOVERY_TIMEOUT}"
+            -P "${CMAKE_CURRENT_LIST_DIR}/add_tests.cmake"
+    VERBATIM
+  )
+
+  file(WRITE "${ctest_include_file}"
+    "if(EXISTS \"${ctest_tests_file}\")\n"
+    "  include(\"${ctest_tests_file}\")\n"
+    "else()\n"
+    "  add_test(${TARGET}_NOT_BUILT ${TARGET}_NOT_BUILT)\n"
+    "endif()\n"
+  )
+
+  # Add discovered tests to directory TEST_INCLUDE_FILES
+  set_property(DIRECTORY
+    APPEND PROPERTY TEST_INCLUDE_FILES "${ctest_include_file}"
+  )
+endfunction()
+
+#add_test(
+#  NAME mytest
+#  COMMAND $<TARGET_FILE:md_unittest>)
+
+discover_tests(md_unittest
+  PROPERTIES
+    LABELS "unit"
+  )

--- a/unittest/add_tests.cmake
+++ b/unittest/add_tests.cmake
@@ -1,0 +1,131 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+cmake_minimum_required(VERSION ${CMAKE_VERSION})
+
+# Overwrite possibly existing ${_CTEST_FILE} with empty file
+set(flush_tests_MODE WRITE)
+
+# Flushes script to ${_CTEST_FILE}
+macro(flush_script)
+  file(${flush_tests_MODE} "${_CTEST_FILE}" "${script}")
+  set(flush_tests_MODE APPEND)
+
+  set(script "")
+endmacro()
+
+# Flushes tests_buffer to tests
+macro(flush_tests_buffer)
+  list(APPEND tests "${tests_buffer}")
+  set(tests_buffer "")
+endmacro()
+
+macro(add_command NAME)
+  set(_args "")
+  foreach(_arg ${ARGN})
+    if(_arg MATCHES "[^-./:a-zA-Z0-9_]")
+      string(APPEND _args " [==[${_arg}]==]")
+    else()
+      string(APPEND _args " ${_arg}")
+    endif()
+  endforeach()
+  string(APPEND script "${NAME}(${_args})\n")
+  string(LENGTH "${script}" _script_len)
+  if(${_script_len} GREATER "50000")
+    flush_script()
+  endif()
+  # Unsets macro local variables to prevent leakage outside of this macro.
+  unset(_args)
+  unset(_script_len)
+endmacro()
+
+function(discover_tests_impl)
+
+  cmake_parse_arguments(
+    ""
+    ""
+    "TEST_EXECUTABLE;TEST_WORKING_DIR;CTEST_FILE;TEST_DISCOVERY_TIMEOUT"
+    "TEST_PROPERTIES"
+    ${ARGN}
+  )
+  set(properties ${_TEST_PROPERTIES})
+  set(script)
+  set(suite)
+  set(tests)
+  set(tests_buffer)
+
+  # Run test executable to get list of available tests
+  if(NOT EXISTS "${_TEST_EXECUTABLE}")
+    message(FATAL_ERROR
+      "Specified test executable does not exist.\n"
+      "  Path: '${_TEST_EXECUTABLE}'"
+    )
+  endif()
+  execute_process(
+    COMMAND "${_TEST_EXECUTABLE}" --list-tests
+    WORKING_DIRECTORY "${_TEST_WORKING_DIR}"
+    TIMEOUT ${_TEST_DISCOVERY_TIMEOUT}
+    OUTPUT_VARIABLE output
+    RESULT_VARIABLE result
+  )
+  if(NOT ${result} EQUAL 0)
+    string(REPLACE "\n" "\n    " output "${output}")
+    message(FATAL_ERROR
+      "Error running test executable.\n"
+      "  Path: '${_TEST_EXECUTABLE}'\n"
+      "  Result: ${result}\n"
+      "  Output:\n"
+      "    ${output}\n"
+    )
+  endif()
+
+  # Preserve semicolon in test-parameters
+  string(REPLACE [[;]] [[\;]] output "${output}")
+  string(REPLACE "\n" ";" output "${output}")
+
+  # Parse output
+  foreach(line ${output})
+    # extract suite and test names
+    string(REPLACE "." ";" _line "${line}")
+    list(GET _line 0 suite)
+    list(GET _line 1 name)
+    set(testname "${suite}.${name}")
+    add_command(add_test
+      "${testname}"
+      "${_TEST_EXECUTABLE}"
+      "--filter=${suite}.${name}"
+    )
+    add_command(set_tests_properties
+      "${testname}"
+      PROPERTIES
+        WORKING_DIRECTORY "${_TEST_WORKING_DIR}"
+        LABELS ${suite}
+        SKIP_REGULAR_EXPRESSION "\\\\[  SKIPPED \\\\]"
+        ${properties}
+    )
+    list(APPEND tests_buffer "${testname}")
+    list(LENGTH tests_buffer tests_buffer_length)
+    if(${tests_buffer_length} GREATER "250")
+      flush_tests_buffer()
+    endif()
+  endforeach()
+
+  # Create a list of all discovered tests, which users may use to e.g. set
+  # properties on the tests
+  flush_tests_buffer()
+  add_command(set ${_TEST_LIST} ${tests})
+
+  # Write CTest script
+  flush_script()
+
+endfunction()
+
+if(CMAKE_SCRIPT_MODE_FILE)
+  discover_tests_impl(
+    TEST_EXECUTABLE ${TEST_EXECUTABLE}
+    TEST_WORKING_DIR ${TEST_WORKING_DIR}
+    CTEST_FILE ${CTEST_FILE}
+    TEST_DISCOVERY_TIMEOUT ${TEST_DISCOVERY_TIMEOUT}
+    TEST_PROPERTIES ${TEST_PROPERTIES}
+  )
+endif()


### PR DESCRIPTION
I've added CMake infrastructure to manage the autodiscovery of unit tests.
You can define the tests in multiple files. Once the `md_unittest` executable is built, CMake will:

- Run `md_unittest --list-tests` to get the list of tests.
- Add a different CTest test name `<suite>.<name>`, where `<suite>` is the first and `<name>` is the second argument, respectively, to the `UTEST` macro.
- Add a `unit` label to all tests.
- Add a `<suite>` label to each test.

CTest will run each test with `md_unittest --filter=<suite>.<name>`.

In the build folder you can:

- Get a list of tests with `ctest -N`.
- Run all tests with `ctest`.
- Run all unit tests with `ctest -L unit` (will do the same as point above)
- Run all unit tests in a suite `ctest -L allocator`.
- Run all unit tests whose name matches a regex `ctest -L pool`.

The functions and macros are adapted from the ones available with CMake itself for Google Test:

- https://github.com/Kitware/CMake/blob/master/Modules/GoogleTest.cmake
- https://github.com/Kitware/CMake/blob/master/Modules/GoogleTestAddTests.cmake